### PR TITLE
Remove destroying a pixmap twice in radeon_glamor.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,12 +133,6 @@ if test "x$GLAMOR" != "xno"; then
 			      [#include "xorg-server.h"
 			       #include "glamor.h"])
 
-		AC_CHECK_DECL(glamor_egl_destroy_textured_pixmap,
-			      [AC_DEFINE(HAVE_GLAMOR_EGL_DESTROY_TEXTURED_PIXMAP, 1,
-					 [Have glamor_egl_destroy_textured_pixmap API])], [],
-			      [#include "xorg-server.h"
-			       #include "glamor.h"])
-
 		AC_CHECK_DECL(glamor_finish,
 			      [AC_DEFINE(HAVE_GLAMOR_FINISH, 1,
 					 [Have glamor_finish API])],

--- a/src/radeon_glamor.c
+++ b/src/radeon_glamor.c
@@ -213,10 +213,10 @@ static Bool radeon_glamor_destroy_pixmap(PixmapPtr pixmap)
 	fbDestroyPixmap(pixmap);
 	return TRUE;
 #else
-	screen->DestroyPixmap = info->glamor.SavedDestroyPixmap;
-	if (screen->DestroyPixmap(pixmap))
+	if (info->glamor.SavedDestroyPixmap) {
+		screen->DestroyPixmap = info->glamor.SavedDestroyPixmap;
 		ret = screen->DestroyPixmap(pixmap);
-	info->glamor.SavedDestroyPixmap = screen->DestroyPixmap;
+	}
 	screen->DestroyPixmap = radeon_glamor_destroy_pixmap;
 
 	return ret;

--- a/src/radeon_glamor.c
+++ b/src/radeon_glamor.c
@@ -196,23 +196,13 @@ radeon_glamor_create_textured_pixmap(PixmapPtr pixmap, struct radeon_buffer *bo)
 
 static Bool radeon_glamor_destroy_pixmap(PixmapPtr pixmap)
 {
-#ifndef HAVE_GLAMOR_EGL_DESTROY_TEXTURED_PIXMAP
 	ScreenPtr screen = pixmap->drawable.pScreen;
 	RADEONInfoPtr info = RADEONPTR(xf86ScreenToScrn(screen));
 	Bool ret = TRUE;
-#endif
 
-	if (pixmap->refcnt == 1) {
-#ifdef HAVE_GLAMOR_EGL_DESTROY_TEXTURED_PIXMAP
-		glamor_egl_destroy_textured_pixmap(pixmap);
-#endif
+	if (pixmap->refcnt == 1)
 		radeon_set_pixmap_bo(pixmap, NULL);
-	}
 
-#ifdef HAVE_GLAMOR_EGL_DESTROY_TEXTURED_PIXMAP
-	fbDestroyPixmap(pixmap);
-	return TRUE;
-#else
 	if (info->glamor.SavedDestroyPixmap) {
 		screen->DestroyPixmap = info->glamor.SavedDestroyPixmap;
 		ret = screen->DestroyPixmap(pixmap);
@@ -220,7 +210,6 @@ static Bool radeon_glamor_destroy_pixmap(PixmapPtr pixmap)
 	screen->DestroyPixmap = radeon_glamor_destroy_pixmap;
 
 	return ret;
-#endif
 }
 
 static PixmapPtr

--- a/src/radeon_kms.c
+++ b/src/radeon_kms.c
@@ -107,7 +107,7 @@ void radeon_cs_flush_indirect(ScrnInfoPtr pScrn)
 
 #ifdef USE_GLAMOR
     if (info->use_glamor) {
-	glamor_block_handler(pScrn->pScreen);
+    /* Pending operations have already been flushed in glamor_close_screen() */
 	return;
     }
 #endif


### PR DESCRIPTION
This patch remove radeon driver crash with --glamor-enabled and fixes https://github.com/X11Libre/xserver/issues/347