### PR TITLE
fix: undefined symbol: glamor_egl_init_textured_pixmap

### DIFF
--- a/src/radeon_glamor.c
+++ b/src/radeon_glamor.c
@@ -463,12 +463,6 @@ radeon_glamor_init(ScreenPtr screen)
 		return FALSE;
 	}
 
-	if (!glamor_egl_init_textured_pixmap(screen)) {
-		xf86DrvMsg(scrn->scrnIndex, X_ERROR,
-			   "Failed to initialize textured pixmap of screen for glamor.\n");
-		return FALSE;
-	}
-
 	if (!dixRegisterPrivateKey(&glamor_pixmap_index, PRIVATE_PIXMAP, 0))
 		return FALSE;
 


### PR DESCRIPTION
The function just returns true now so there is no point to this code which fails to find the function symbol any way.