### PR TITLE
radeon_glamor_wrappers: fix missing include of <fbpict.h>

### DIFF
--- a/src/radeon_glamor_wrappers.c
+++ b/src/radeon_glamor_wrappers.c
@@ -32,6 +32,8 @@
 #include <config.h>
 #endif
 
+#include <fbpict.h>
+
 #ifdef USE_GLAMOR
 
 #include "radeon.h"


### PR DESCRIPTION
Fixes:
- https://github.com/X11Libre/ports-gentoo/issues/51
- https://github.com/X11Libre/xf86-video-ati/issues/10