### PR TITLE
configure: fix broken xserver version detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,16 +160,6 @@ AC_CHECK_DECL(RegionDuplicate,
 	      [#include <xorg-server.h>
 	       #include <regionstr.h>])
 
-AC_CHECK_DECL(fbGlyphs,
-	      [AC_DEFINE(HAVE_FBGLYPHS, 1, [Have fbGlyphs API])], [],
-	      [#include <X11/Xmd.h>
-	       #include <X11/Xfuncproto.h>
-	       #include <X11/extensions/renderproto.h>
-	       #include <xorg-server.h>
-	       #include <picture.h>
-	       #include <glyphstr.h>
-	       #include <fbpict.h>])
-
 AC_CHECK_DECL(xf86CursorResetCursor,
 	      [AC_DEFINE(HAVE_XF86_CURSOR_RESET_CURSOR, 1,
 	      [Have xf86CursorResetCursor API])], [],

--- a/src/radeon_glamor.c
+++ b/src/radeon_glamor.c
@@ -425,18 +425,14 @@ radeon_glamor_init(ScreenPtr screen)
 	ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
 	RADEONInfoPtr info = RADEONPTR(scrn);
 #ifdef RENDER
-#ifdef HAVE_FBGLYPHS
 	UnrealizeGlyphProcPtr SavedUnrealizeGlyph = NULL;
-#endif
 	PictureScreenPtr ps = NULL;
 
 	if (info->shadow_primary) {
 		ps = GetPictureScreenIfSet(screen);
 
 		if (ps) {
-#ifdef HAVE_FBGLYPHS
 			SavedUnrealizeGlyph = ps->UnrealizeGlyph;
-#endif
 			info->glamor.SavedGlyphs = ps->Glyphs;
 			info->glamor.SavedTriangles = ps->Triangles;
 			info->glamor.SavedTrapezoids = ps->Trapezoids;
@@ -458,7 +454,7 @@ radeon_glamor_init(ScreenPtr screen)
 	if (info->shadow_primary)
 		radeon_glamor_screen_init(screen);
 
-#if defined(RENDER) && defined(HAVE_FBGLYPHS)
+#if defined(RENDER)
 	/* For ShadowPrimary, we need fbUnrealizeGlyph instead of
 	 * glamor_unrealize_glyph
 	 */


### PR DESCRIPTION
Back a decade ago, somebody obviously idn't know how to check for xserver version and abused a quite unrelated exported symbol instead. Since that symbol isn't exported anymore (because no driver was using it), this black magic now fails.

We're not trying to support more than a decade old Xservers, so there's no point in this check at all, just drop it.

Fixes: ae92d1765fa370a8d94c2856ad6c45d273ec3c69