### PR TITLE
Mistypes in #include "fb.h" corrected and #include <fb_pict.h> added to fix compilation error

### DIFF
--- a/src/radeon_glamor_wrappers.c
+++ b/src/radeon_glamor_wrappers.c
@@ -34,7 +34,8 @@
 
 #ifdef USE_GLAMOR
 
-#include "fb.h"
+#include <fb.h>
+#include <fbpict.h>
 
 #include "radeon.h"
 #include "radeon_bo_helper.h"

--- a/src/radeon_kms.c
+++ b/src/radeon_kms.c
@@ -60,7 +60,7 @@
 
 #include <X11/extensions/damageproto.h>
 
-#include "fb.h"
+#include <fb.h>
 #include "radeon_chipinfo_gen.h"
 
 #include "radeon_bo_gem.h"


### PR DESCRIPTION
Now build errors appear, see https://github.com/X11Libre/xf86-video-ati/pull/13#issuecomment-3131675264

To avoid this, inclusions should be in angle quotes, and <fb_pict.h> should also be included in radeon_glamor_wrappers.c.