### PR TITLE
radeon_glamor_wrappers: fix missing include of fbpict.h

### DIFF
--- a/src/radeon_glamor_wrappers.c
+++ b/src/radeon_glamor_wrappers.c
@@ -34,7 +34,8 @@
 
 #ifdef USE_GLAMOR
 
-#include "fb.h"
+#include <fb.h>
+#include <fbpict.h>
 
 #include "radeon.h"
 #include "radeon_bo_helper.h"

--- a/src/radeon_kms.c
+++ b/src/radeon_kms.c
@@ -60,7 +60,8 @@
 
 #include <X11/extensions/damageproto.h>
 
-#include "fb.h"
+#include <fb.h>
+
 #include "radeon_chipinfo_gen.h"
 
 #include "radeon_bo_gem.h"


### PR DESCRIPTION
We're calling fbComposite() and fbAddTraps() here, which are defined in <fbpict.h>.