### PR TITLE
radeon: drop duplicate (and incompatible) definition of FOURCC_RGBA32

### DIFF
--- a/src/radeon_textured_video.c
+++ b/src/radeon_textured_video.c
@@ -758,7 +758,6 @@ RADEONQueryBestSize(
 #define FOURCC_RGB24    0x00000000
 #define FOURCC_RGBT16   0x54424752
 #define FOURCC_RGB16    0x32424752
-#define FOURCC_RGBA32   0x41424752
 
 static int
 RADEONQueryImageAttributes(


### PR DESCRIPTION
Already defined by the Xserver SDK, and we also should it's value instead of some entirely different one.